### PR TITLE
Array Declaration Bug Fix

### DIFF
--- a/src/IDE.php
+++ b/src/IDE.php
@@ -12,7 +12,7 @@ class IDE
 	public $site_url, $plugin_url;
 	private $menu_hook;
 
-	private $modules = [];
+	private $modules = array();
 
 	function __construct() {
 		$this->site_url = get_bloginfo('url');


### PR DESCRIPTION
Unexpected character error fixed with array() declaration.
It was impossible for me to activate the plugin before I made this fix.
