### PR TITLE
Adding .SCSS file syntax highlighting support

### DIFF
--- a/src/IDE.php
+++ b/src/IDE.php
@@ -155,6 +155,7 @@ class IDE
 		wp_enqueue_script( 'ace', "{$plugin_url}src/js/ace-{$acever}/ace.js", array(), $idever );
 		// include ace modes for css, javascript & php
 		wp_enqueue_script( 'ace-mode-css', "{$plugin_url}src/js/ace-{$acever}/mode-css.js", array( 'ace' ), $idever );
+		wp_enqueue_script( 'ace-mode-scss', "{$plugin_url}src/js/ace-{$acever}/mode-scss.js", array( 'ace' ), $idever );
 		wp_enqueue_script( 'ace-mode-less', "{$plugin_url}src/js/ace-{$acever}/mode-less.js", array( 'ace' ), $idever );
 		wp_enqueue_script( 'ace-mode-javascript', "{$plugin_url}src/js/ace-{$acever}/mode-javascript.js", array( 'ace' ), $idever );
 		wp_enqueue_script( 'ace-mode-php', "{$plugin_url}src/js/ace-{$acever}/mode-php.js", array( 'ace' ), $idever );

--- a/src/js/load-editor.js
+++ b/src/js/load-editor.js
@@ -563,6 +563,9 @@ function aceide_set_file_contents(file, callback_func){
 			if (/\.css$/.test(currentFilename)) {
 				mode = require("ace/mode/css").Mode;
 			}
+			if (/\.scss$/.test(currentFilename)) {
+				mode = require("ace/mode/scss").Mode;
+			}
 			else if (/\.less$/.test(currentFilename)) {
 				mode = require("ace/mode/less").Mode;
 			}


### PR DESCRIPTION
I added .SCSS file syntax highlighting support for use with [WP-SCSS](https://wordpress.org/plugins/wp-scss/)